### PR TITLE
feat: be able to share the hauk url from the gotify notification

### DIFF
--- a/notification/notifier.go
+++ b/notification/notifier.go
@@ -40,7 +40,8 @@ func (t *notifier) NotifyNewSession(topic string, URL string) {
 				"contentType": "text/markdown",
 			},
 			"client::notification": map[string]interface{}{
-				"click": map[string]interface{}{"url": URL},
+				"click":   map[string]interface{}{"url": URL},
+				"actions": map[string]interface{}{"share": URL},
 			},
 		}
 
@@ -62,8 +63,8 @@ func (t *notifier) NotifyNewSession(topic string, URL string) {
 	if t.config.Smtp.Enabled {
 		host := fmt.Sprintf("%s:%d", t.config.Smtp.Host, t.config.Smtp.Port)
 		var auth smtp.Auth
-	        if t.config.Smtp.Login != "" {
-                       auth = smtp.PlainAuth("", t.config.Smtp.Login, t.config.Smtp.Password, t.config.Smtp.Host)
+		if t.config.Smtp.Login != "" {
+			auth = smtp.PlainAuth("", t.config.Smtp.Login, t.config.Smtp.Password, t.config.Smtp.Host)
 		}
 		err := smtp.SendMail(host, auth, t.config.Smtp.From, []string{t.config.Smtp.To}, []byte(fmt.Sprintf("Subject: Forwarding %s to Hauk\r\n\r\nNew session: %s", topic, URL)))
 		if err != nil {


### PR DESCRIPTION
This will be nice to be able to share the url with chat apps for example without open the link ourself.

I did the gotify android PR to make this working.

This can be merge before the gotify android but il will only work when this PR is merged https://github.com/gotify/android/pull/236. Lets wait for this get merged.